### PR TITLE
fix the potential security vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>uk.ac.ebi.ddi</groupId>
     <artifactId>ddi-ebe-ws-dao</artifactId>
-    <version>1.2</version>
+    <version>1.3-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>ddi-ebe-ws-dao</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>19.0</version>
+            <version>28.1-jre</version>
         </dependency>
 
 


### PR DESCRIPTION
Merge to fix the potential security vulnerability: 

Unbounded memory allocation in Google Guava 11.0 through 24.x before 24.1.1 allows
remote attackers to conduct denial of service attacks against servers that depend
on this library and deserialize attacker-provided data.